### PR TITLE
Use .toFilePath() to convert Uris to file paths

### DIFF
--- a/lib/src/shim.dart
+++ b/lib/src/shim.dart
@@ -483,8 +483,7 @@ String _hoverMessage(HoverInformation hover) {
   return '$message';
 }
 
-String _filePath(String fileUri) =>
-    Uri.decodeComponent(Uri.parse(fileUri).path);
+String _filePath(String fileUri) => Uri.parse(fileUri).toFilePath();
 
 List<Location> _toLocationList(SearchResults results, FileCache files) =>
     results.results


### PR DESCRIPTION
This handles Windows paths whereas `.path` is always just `/like/this`.