### PR TITLE
Use directory.systemTemp for log paths

### DIFF
--- a/bin/dart_language_server.dart
+++ b/bin/dart_language_server.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 
 import 'package:dart_language_server/dart_language_server.dart';
 import 'package:dart_language_server/src/args.dart';
+import 'package:path/path.dart' as path;
 
 Future main(List<String> args) async {
   StartupArgs startupArgs;
@@ -17,11 +18,13 @@ Future main(List<String> args) async {
       var shim = await startShimmedServer(startupArgs);
       await new StdIOLanguageServer.start(shim).onDone;
     } catch (e, st) {
-      await new File('/tmp/lsp-error.log').writeAsString('Caught $e\n$st');
+      await new File(path.join(Directory.systemTemp.path, 'lsp-error.txt'))
+          .writeAsString('Caught $e\n$st');
     } finally {
       await closeLogs();
     }
   }, onError: (e, st) {
-    new File('/tmp/lsp-error.log').writeAsString('UnCaught $e\n$st');
+    new File(path.join(Directory.systemTemp.path, 'lsp-error.txt'))
+        .writeAsString('UnCaught $e\n$st');
   });
 }

--- a/lib/src/logging/logs.dart
+++ b/lib/src/logging/logs.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:logging/logging.dart';
+import 'package:path/path.dart' as path;
 import 'package:stream_channel/stream_channel.dart';
 
 import 'wirelog.dart';
@@ -15,7 +16,9 @@ final _logs = <IOSink>[];
 
 void startLogging(String clientName, String traceLevel) {
   if (traceLevel == 'verbose') {
-    var logSink = new File('/tmp/dart-lang-server-$clientName.log').openWrite();
+    var logSink = new File(path.join(
+            Directory.systemTemp.path, 'dart-lang-server-$clientName.log'))
+        .openWrite();
     _logs.add(logSink);
     Logger.root.level = Level.ALL;
     Logger.root.onRecord.listen((record) {
@@ -28,11 +31,14 @@ void startLogging(String clientName, String traceLevel) {
     });
   }
   if (traceLevel == 'verbose' || traceLevel == 'messages') {
-    var analyzerLog =
-        new File('/tmp/analyzer-wirelog-$clientName.log').openWrite();
+    var analyzerLog = new File(path.join(
+            Directory.systemTemp.path, 'analyzer-wirelog-$clientName.log'))
+        .openWrite();
     analyzerSink.stream.transform(UTF8.encoder).pipe(analyzerLog);
     _logs.add(analyzerLog);
-    var lspLog = new File('/tmp/lsp-wirelog-$clientName.log').openWrite();
+    var lspLog = new File(
+            path.join(Directory.systemTemp.path, 'lsp-wirelog-$clientName.log'))
+        .openWrite();
     _lspWireLog.attach(lspLog);
     _logs.add(lspLog);
   }


### PR DESCRIPTION
Makes these Windows-friendly (they end up in `%TEMP%`, which despite being labelled by Dart as "system temp" is actually, user-specific, eg. `C:\Users\danny\AppData\Local\Temp`).