### PR TITLE
Handle detecting package roots for Windows

### DIFF
--- a/lib/src/utils/package_dir_detection.dart
+++ b/lib/src/utils/package_dir_detection.dart
@@ -16,6 +16,6 @@ Directory _findParentPackageDir(Directory dir) {
   return _findParentPackageDir(parent);
 }
 
-bool _isPackageRoot(Directory dir) => dir
-    .listSync()
-    .any((f) => f.path.endsWith('/pubspec.yaml') || f.path.endsWith('/BUILD'));
+bool _isPackageRoot(Directory dir) => dir.listSync().any((f) =>
+    f.path.endsWith('${Platform.pathSeparator}pubspec.yaml') ||
+    f.path.endsWith('${Platform.pathSeparator}BUILD'));


### PR DESCRIPTION
Wasn't sure if worth putting this in a variable; but fixes on Windows that it would never detect the root so always just add the specific folder (eg. `bin`).