### PR TITLE
Handle Windows line endings when converting positions/offsets.

### DIFF
--- a/lib/src/position_convert.dart
+++ b/lib/src/position_convert.dart
@@ -5,8 +5,7 @@ int offsetFromPosition(Iterable<int> lineLengths, Position position) =>
     _offset(lineLengths, position.line, position.character);
 
 int _offset(Iterable<int> lineLengths, int line, int character) {
-  var fullLines =
-      lineLengths.take(line).fold(0, (sum, length) => sum + length + 1);
+  var fullLines = lineLengths.take(line).fold(0, (sum, length) => sum + length);
   return fullLines + character;
 }
 
@@ -26,9 +25,9 @@ Position positionFromOffset(Iterable<int> lineLengths, int offset) {
   var consumedCharacters = 0;
   var consumedLines = 0;
   for (var length in lineLengths) {
-    if (consumedCharacters + length + 1 > offset) break;
+    if (consumedCharacters + length > offset) break;
     consumedLines += 1;
-    consumedCharacters += length + 1;
+    consumedCharacters += length;
   }
   return new Position((b) => b
     ..line = consumedLines

--- a/lib/src/position_convert.dart
+++ b/lib/src/position_convert.dart
@@ -40,8 +40,15 @@ OffsetLength offsetLengthFromRange(Iterable<int> lineLengths, Range range) {
   return new OffsetLength(offset, endOffset - offset);
 }
 
-List<int> findLineLengths(String file) =>
-    file.split('\n').map((l) => l.length).toList();
+List<int> findLineLengths(String contents) {
+  // To avoid confusion, we add the \n back on to the length, so the lengths
+  // include line endings.
+  final lineLengths = contents.split("\n").map((l) => l.length + 1).toList();
+  // Remove the +1 we added on to the last one that didn't really exist.
+  lineLengths[lineLengths.length - 1]--;
+
+  return lineLengths;
+}
 
 class OffsetLength {
   final int offset;

--- a/lib/src/utils/file_cache.dart
+++ b/lib/src/utils/file_cache.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+import 'package:dart_language_server/src/position_convert.dart';
+
 /// Caches file line lengths by file path, useful for translating between
 /// differing representations of location.
 ///
@@ -15,21 +17,10 @@ class FileCache {
     assert(filePath is String);
     if (_activeFiles.containsKey(filePath)) return _activeFiles[filePath];
     // Don't use readAsLines() or we'll lose track of the different line endings (\r\n).
-    return splitIntoLines(new File(filePath).readAsStringSync());
+    return findLineLengths(new File(filePath).readAsStringSync());
   }
 
   void operator []=(String filePath, List<int> lines) {
     _activeFiles[filePath] = lines;
   }
-}
-
-// TODO: Where should this live?
-List<int> splitIntoLines(String contents) {
-  // To avoid confusion, we add the \n back on to the length, so the lengths
-  // include line endings.
-  final lineLengths = contents.split("\n").map((l) => l.length + 1).toList();
-  // Remove the +1 we added on to the last one that didn't really exist.
-  lineLengths[lineLengths.length - 1]--;
-
-  return lineLengths;
 }

--- a/lib/src/utils/file_cache.dart
+++ b/lib/src/utils/file_cache.dart
@@ -14,10 +14,22 @@ class FileCache {
   List<int> operator [](Object filePath) {
     assert(filePath is String);
     if (_activeFiles.containsKey(filePath)) return _activeFiles[filePath];
-    return new File(filePath).readAsLinesSync().map((l) => l.length).toList();
+    // Don't use readAsLines() or we'll lose track of the different line endings (\r\n).
+    return splitIntoLines(new File(filePath).readAsStringSync());
   }
 
   void operator []=(String filePath, List<int> lines) {
     _activeFiles[filePath] = lines;
   }
+}
+
+// TODO: Where should this live?
+List<int> splitIntoLines(String contents) {
+  // To avoid confusion, we add the \n back on to the length, so the lengths
+  // include line endings.
+  final lineLengths = contents.split("\n").map((l) => l.length + 1).toList();
+  // Remove the +1 we added on to the last one that didn't really exist.
+  lineLengths[lineLengths.length - 1]--;
+
+  return lineLengths;
 }

--- a/test/position_convert_test.dart
+++ b/test/position_convert_test.dart
@@ -1,6 +1,5 @@
 import 'package:dart_language_server/src/position_convert.dart';
 import 'package:dart_language_server/src/protocol/language_server/messages.dart';
-import 'package:dart_language_server/src/utils/file_cache.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -12,7 +11,7 @@ void main() {
     if (windowsFile)
       group('${windowsFile ? "Windows" : "macOS"} line endings', () {
         final lines =
-            splitIntoLines(windowsFile ? file.replaceAll("\n", "\r\n") : file);
+            findLineLengths(windowsFile ? file.replaceAll("\n", "\r\n") : file);
         group('offsetFromPosition', () {
           test('start of file', () async {
             var start = new Position((b) => b

--- a/test/position_convert_test.dart
+++ b/test/position_convert_test.dart
@@ -1,110 +1,119 @@
-import 'package:test/test.dart';
-
 import 'package:dart_language_server/src/position_convert.dart';
 import 'package:dart_language_server/src/protocol/language_server/messages.dart';
+import 'package:dart_language_server/src/utils/file_cache.dart';
+import 'package:test/test.dart';
 
 void main() {
   const file = 'line 1\n'
       'longer line 2\n'
       '\n'
       'line following blank\n';
-  final lines = file.split('\n').map((l) => l.length);
-  group('offsetFromPosition', () {
-    test('start of file', () async {
-      var start = new Position((b) => b
-        ..line = 0
-        ..character = 0);
-      expect(offsetFromPosition(lines, start), 0);
-    });
-    test('start of line', () async {
-      var startOfLine = new Position((b) => b
-        ..line = 1
-        ..character = 0);
-      expect(offsetFromPosition(lines, startOfLine), 7);
-    });
-    test('end of line', () async {
-      var endOfLine = new Position((b) => b
-        ..line = 1
-        ..character = 12);
-      expect(offsetFromPosition(lines, endOfLine), 19);
-    });
-    test('line after blank', () async {
-      var lineAfterBlank = new Position((b) => b
-        ..line = 3
-        ..character = 0);
-      expect(offsetFromPosition(lines, lineAfterBlank), 22);
-    });
-  });
-
-  group('positionFromOffset', () {
-    test('start of file', () async {
-      expect(
-          positionFromOffset(lines, 0).toJson(),
-          new Position((b) => b
-            ..line = 0
-            ..character = 0).toJson());
-    });
-
-    test('start of line', () async {
-      expect(
-          positionFromOffset(lines, 7).toJson(),
-          new Position(((b) => b
-                ..line = 1
-                ..character = 0))
-              .toJson());
-    });
-
-    test('end of line', () async {
-      expect(
-          positionFromOffset(lines, 19).toJson(),
-          new Position((b) => b
-            ..line = 1
-            ..character = 12).toJson());
-    });
-    test('after blank line', () async {
-      expect(
-          positionFromOffset(lines, 22).toJson(),
-          new Position((b) => b
-            ..line = 3
-            ..character = 0).toJson());
-    });
-  });
-
-  group('rangeFromOffset', () {
-    test('start of file', () async {
-      expect(
-          rangeFromOffset(lines, 0, 3).toJson(),
-          new Range((b) => b
-            ..start = new Position((b) => b
+  [false, true].forEach((windowsFile) {
+    if (windowsFile)
+      group('${windowsFile ? "Windows" : "macOS"} line endings', () {
+        final lines =
+            splitIntoLines(windowsFile ? file.replaceAll("\n", "\r\n") : file);
+        group('offsetFromPosition', () {
+          test('start of file', () async {
+            var start = new Position((b) => b
               ..line = 0
-              ..character = 0)
-            ..end = new Position((b) => b
-              ..line = 0
-              ..character = 3)).toJson());
-    });
-
-    test('start of line', () async {
-      expect(
-          rangeFromOffset(lines, 7, 5).toJson(),
-          new Range((b) => b
-            ..start = new Position((b) => b
+              ..character = 0);
+            expect(offsetFromPosition(lines, start), 0);
+          });
+          test('start of line', () async {
+            var startOfLine = new Position((b) => b
               ..line = 1
-              ..character = 0)
-            ..end = new Position((b) => b
+              ..character = 0);
+            expect(offsetFromPosition(lines, startOfLine), windowsFile ? 8 : 7);
+          });
+          test('end of line', () async {
+            var endOfLine = new Position((b) => b
               ..line = 1
-              ..character = 5)).toJson());
-    });
-
-    test('across lines', () async {
-      expect(
-          rangeFromOffset(lines, 14, 11).toJson(),
-          new Range((b) => b
-            ..start = new Position((b) => b
-              ..line = 1
-              ..character = 7)
-            ..end = new Position((b) => b
+              ..character = 12);
+            expect(offsetFromPosition(lines, endOfLine), windowsFile ? 20 : 19);
+          });
+          test('line after blank', () async {
+            var lineAfterBlank = new Position((b) => b
               ..line = 3
-              ..character = 3)).toJson());
-    });
+              ..character = 0);
+            expect(offsetFromPosition(lines, lineAfterBlank),
+                windowsFile ? 25 : 22);
+          });
+        });
+
+        group('positionFromOffset', () {
+          test('start of file', () async {
+            expect(
+                positionFromOffset(lines, 0).toJson(),
+                new Position((b) => b
+                  ..line = 0
+                  ..character = 0).toJson());
+          });
+
+          test('start of line', () async {
+            expect(
+                positionFromOffset(lines, windowsFile ? 8 : 7).toJson(),
+                new Position(((b) => b
+                      ..line = 1
+                      ..character = 0))
+                    .toJson());
+          });
+
+          test('end of line', () async {
+            expect(
+                positionFromOffset(lines, windowsFile ? 20 : 19).toJson(),
+                new Position((b) => b
+                  ..line = 1
+                  ..character = 12).toJson());
+          });
+          test('after blank line', () async {
+            expect(
+                positionFromOffset(lines, windowsFile ? 25 : 22).toJson(),
+                new Position((b) => b
+                  ..line = 3
+                  ..character = 0).toJson());
+          });
+        });
+
+        group('rangeFromOffset', () {
+          test('start of file', () async {
+            expect(
+                rangeFromOffset(lines, 0, 3).toJson(),
+                new Range((b) => b
+                  ..start = new Position((b) => b
+                    ..line = 0
+                    ..character = 0)
+                  ..end = new Position((b) => b
+                    ..line = 0
+                    ..character = 3)).toJson());
+          });
+
+          test('start of line', () async {
+            expect(
+                rangeFromOffset(lines, windowsFile ? 8 : 7, 5).toJson(),
+                new Range((b) => b
+                  ..start = new Position((b) => b
+                    ..line = 1
+                    ..character = 0)
+                  ..end = new Position((b) => b
+                    ..line = 1
+                    ..character = 5)).toJson());
+          });
+
+          test('across lines', () async {
+            expect(
+                rangeFromOffset(
+                        lines, windowsFile ? 15 : 14, windowsFile ? 13 : 11)
+                    .toJson(),
+                new Range((b) => b
+                  ..start = new Position((b) => b
+                    ..line = 1
+                    ..character = 7)
+                  ..end = new Position((b) => b
+                    ..line = 3
+                    ..character = 3)).toJson());
+          });
+        });
+      });
   });
 }


### PR DESCRIPTION
This fixes #32 by changing the lineLengths that are stored to include the end-of-line character(s) in the counts. Without it, you can't reliably translate the positions (it's possible a file has mixed line endings within the same file). I wasn't sure if there was a better way to do it (I saw the `splitMarker` function but it didn't seem used and wasn't totally sure whether it was doing what I needed).

This code is kinda messy for a few reasons:

1. In an attempt to avoid copy/pasting the entire set of sets, I put ternary operators in for the expected values, and it turned out kinda messy
2. In order to avoid duplicating the line-splitting logic, I added a `splitIntoLines` function in `file_cache.dart` that probably should be somewhere else.

Possibly for `1` you could dynamically get the expected values from the `file` string with a search? For example in Dart Code's tests we have things like this (which I think I stole from the analysis server tests):

```ts
ext.exports.renameProvider.prepareRename(doc, positionOf("D^anny"), null);
```

This does a search for the string `Danny` and then gets the position between the `D` and `a`. This makes it easy to modify the files without all the offsets in tests changing and needing updating.

Anyway, let me know what you think - I'm happy to make things better before you merge as required (also, it'd be good to run these tests on Travis+AppVeyor so they're run on both platforms for future checkins and for PRs :-))