### PR TITLE
Restore old behavior for finding line lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.11+5
+
+- Bug fix for mishandled edits which could cause offset calculations to become
+  inaccurate.
+
 # 0.1.11+4
 
 - Bug fix for converting positions in files with windows line endings.

--- a/lib/src/position_convert.dart
+++ b/lib/src/position_convert.dart
@@ -5,7 +5,8 @@ int offsetFromPosition(Iterable<int> lineLengths, Position position) =>
     _offset(lineLengths, position.line, position.character);
 
 int _offset(Iterable<int> lineLengths, int line, int character) {
-  var fullLines = lineLengths.take(line).fold(0, (sum, length) => sum + length);
+  var fullLines =
+      lineLengths.take(line).fold(0, (sum, length) => sum + length + 1);
   return fullLines + character;
 }
 
@@ -25,9 +26,9 @@ Position positionFromOffset(Iterable<int> lineLengths, int offset) {
   var consumedCharacters = 0;
   var consumedLines = 0;
   for (var length in lineLengths) {
-    if (consumedCharacters + length > offset) break;
+    if (consumedCharacters + length + 1 > offset) break;
     consumedLines += 1;
-    consumedCharacters += length;
+    consumedCharacters += length + 1;
   }
   return new Position((b) => b
     ..line = consumedLines
@@ -40,15 +41,8 @@ OffsetLength offsetLengthFromRange(Iterable<int> lineLengths, Range range) {
   return new OffsetLength(offset, endOffset - offset);
 }
 
-List<int> findLineLengths(String contents) {
-  // To avoid confusion, we add the \n back on to the length, so the lengths
-  // include line endings.
-  final lineLengths = contents.split("\n").map((l) => l.length + 1).toList();
-  // Remove the +1 we added on to the last one that didn't really exist.
-  lineLengths[lineLengths.length - 1]--;
-
-  return lineLengths;
-}
+List<int> findLineLengths(String file) =>
+    file.split('\n').map((l) => l.length).toList();
 
 class OffsetLength {
   final int offset;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_language_server
-version: 0.1.11+4
+version: 0.1.11+5
 description: >-
   A shim on the analysis server following the language server protocol
 homepage: https://github.com/natebosch/dart_language_server


### PR DESCRIPTION
Use an implicit `+1` for the `\n` in calculations, but continue to split
strings by `\n` always instead of using `readAsLines`.