### PR TITLE
Fix typo in --force_trace_level help string

### DIFF
--- a/lib/src/args.dart
+++ b/lib/src/args.dart
@@ -10,7 +10,7 @@ class StartupArgs {
   factory StartupArgs(List<String> args) {
     final parser = new ArgParser()
       ..addOption(_forceTraceLevel,
-          help: 'Override the `trace` option duriong initialization',
+          help: 'Override the `trace` option during initialization',
           allowed: ['trace', 'verbose', 'off']);
     try {
       final result = parser.parse(args);


### PR DESCRIPTION
Hi,

when I tried to run this project, I came across a typo in the help message of the --force_trace_level option.

This fixes this typo.

Best regards,
Jonas