### PR TITLE
Send hovers with "plaintext" kind for clients that request them

### DIFF
--- a/lib/src/protocol/language_server/interface.dart
+++ b/lib/src/protocol/language_server/interface.dart
@@ -31,7 +31,8 @@ abstract class LanguageServer {
   Future<List<SymbolInformation>> textDocumentSymbols(
       TextDocumentIdentifier documentId);
   Future<List<SymbolInformation>> workspaceSymbol(String query);
-  Future<Hover> textDocumentHover(
+  // TODO(dantup): How to make this Future<Hover | HoverMarkup>?!
+  Future<dynamic> textDocumentHover(
       TextDocumentIdentifier documentId, Position position);
   Future<List<Command>> textDocumentCodeAction(
       TextDocumentIdentifier documentId,

--- a/lib/src/protocol/language_server/interface.dart
+++ b/lib/src/protocol/language_server/interface.dart
@@ -31,7 +31,6 @@ abstract class LanguageServer {
   Future<List<SymbolInformation>> textDocumentSymbols(
       TextDocumentIdentifier documentId);
   Future<List<SymbolInformation>> workspaceSymbol(String query);
-  // TODO(dantup): How to make this Future<Hover | HoverMarkup>?!
   Future<dynamic> textDocumentHover(
       TextDocumentIdentifier documentId, Position position);
   Future<List<Command>> textDocumentCodeAction(

--- a/lib/src/protocol/language_server/messages.dart
+++ b/lib/src/protocol/language_server/messages.dart
@@ -1298,17 +1298,17 @@ class MarkupContent {
 
   factory MarkupContent.fromJson(Map params) => new MarkupContent._(
       params.containsKey('kind') && params['kind'] != null
-          ? params['kind']
+          ? new MarkupContentKind.fromJson(params['kind'])
           : null,
       params.containsKey('value') && params['value'] != null
           ? params['value']
           : null);
 
-  final String kind;
+  final MarkupContentKind kind;
 
   final String value;
 
-  Map toJson() => {'kind': kind, 'value': value};
+  Map toJson() => {'kind': kind?.toJson(), 'value': value};
   @override
   int get hashCode {
     var hash = 0;
@@ -1330,9 +1330,29 @@ class MarkupContent {
 class MarkupContent$Builder {
   MarkupContent$Builder._();
 
-  String kind;
+  MarkupContentKind kind;
 
   String value;
+}
+
+class MarkupContentKind {
+  factory MarkupContentKind.fromJson(String value) {
+    const values = const {
+      'markdown': MarkupContentKind.markdown,
+      'plaintext': MarkupContentKind.plaintext
+    };
+    return values[value];
+  }
+
+  const MarkupContentKind._(this._value);
+
+  static const markdown = const MarkupContentKind._('markdown');
+
+  static const plaintext = const MarkupContentKind._('plaintext');
+
+  final String _value;
+
+  String toJson() => _value;
 }
 
 class Position {

--- a/lib/src/protocol/language_server/messages.dart
+++ b/lib/src/protocol/language_server/messages.dart
@@ -1119,6 +1119,106 @@ class Hover$Builder {
   Range range;
 }
 
+class HoverCapabilities {
+  HoverCapabilities._(this.contentFormat, this.dynamicRegistration);
+
+  factory HoverCapabilities(void Function(HoverCapabilities$Builder) init) {
+    final b = new HoverCapabilities$Builder._();
+    init(b);
+    return new HoverCapabilities._(b.contentFormat, b.dynamicRegistration);
+  }
+
+  factory HoverCapabilities.fromJson(Map params) => new HoverCapabilities._(
+      params.containsKey('contentFormat') && params['contentFormat'] != null
+          ? params['contentFormat']
+          : null,
+      params.containsKey('dynamicRegistration') &&
+              params['dynamicRegistration'] != null
+          ? params['dynamicRegistration']
+          : null);
+
+  final List<String> contentFormat;
+
+  final bool dynamicRegistration;
+
+  Map toJson() => {
+        'contentFormat': contentFormat,
+        'dynamicRegistration': dynamicRegistration
+      };
+  @override
+  int get hashCode {
+    var hash = 0;
+    hash = _hashCombine(hash, _deepHashCode(contentFormat));
+    hash = _hashCombine(hash, _deepHashCode(dynamicRegistration));
+    return _hashComplete(hash);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! HoverCapabilities) return false;
+    var o = other as HoverCapabilities;
+    if (!_deepEquals(contentFormat, o.contentFormat)) return false;
+    if (dynamicRegistration != o.dynamicRegistration) return false;
+    return true;
+  }
+}
+
+class HoverCapabilities$Builder {
+  HoverCapabilities$Builder._();
+
+  List<String> contentFormat;
+
+  bool dynamicRegistration;
+}
+
+class HoverMarkup {
+  HoverMarkup._(this.contents, this.range);
+
+  factory HoverMarkup(void Function(HoverMarkup$Builder) init) {
+    final b = new HoverMarkup$Builder._();
+    init(b);
+    return new HoverMarkup._(b.contents, b.range);
+  }
+
+  factory HoverMarkup.fromJson(Map params) => new HoverMarkup._(
+      params.containsKey('contents') && params['contents'] != null
+          ? new MarkupContent.fromJson(params['contents'])
+          : null,
+      params.containsKey('range') && params['range'] != null
+          ? new Range.fromJson(params['range'])
+          : null);
+
+  final MarkupContent contents;
+
+  final Range range;
+
+  Map toJson() => {'contents': contents?.toJson(), 'range': range?.toJson()};
+  @override
+  int get hashCode {
+    var hash = 0;
+    hash = _hashCombine(hash, _deepHashCode(contents));
+    hash = _hashCombine(hash, _deepHashCode(range));
+    return _hashComplete(hash);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! HoverMarkup) return false;
+    var o = other as HoverMarkup;
+    if (contents != o.contents) return false;
+    if (range != o.range) return false;
+    return true;
+  }
+}
+
+class HoverMarkup$Builder {
+  HoverMarkup$Builder._();
+
+  MarkupContent contents;
+
+  Range range;
+}
+
 class InsertTextFormat {
   factory InsertTextFormat.fromJson(int value) {
     const values = const {
@@ -1185,6 +1285,54 @@ class Location$Builder {
   Range range;
 
   String uri;
+}
+
+class MarkupContent {
+  MarkupContent._(this.kind, this.value);
+
+  factory MarkupContent(void Function(MarkupContent$Builder) init) {
+    final b = new MarkupContent$Builder._();
+    init(b);
+    return new MarkupContent._(b.kind, b.value);
+  }
+
+  factory MarkupContent.fromJson(Map params) => new MarkupContent._(
+      params.containsKey('kind') && params['kind'] != null
+          ? params['kind']
+          : null,
+      params.containsKey('value') && params['value'] != null
+          ? params['value']
+          : null);
+
+  final String kind;
+
+  final String value;
+
+  Map toJson() => {'kind': kind, 'value': value};
+  @override
+  int get hashCode {
+    var hash = 0;
+    hash = _hashCombine(hash, _deepHashCode(kind));
+    hash = _hashCombine(hash, _deepHashCode(value));
+    return _hashComplete(hash);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! MarkupContent) return false;
+    var o = other as MarkupContent;
+    if (kind != o.kind) return false;
+    if (value != o.value) return false;
+    return true;
+  }
+}
+
+class MarkupContent$Builder {
+  MarkupContent$Builder._();
+
+  String kind;
+
+  String value;
 }
 
 class Position {
@@ -1955,7 +2103,7 @@ class TextDocumentClientCapabilities {
               ? new DynamicRegistrationCapability.fromJson(params['formatting'])
               : null,
           params.containsKey('hover') && params['hover'] != null
-              ? new DynamicRegistrationCapability.fromJson(params['hover'])
+              ? new HoverCapabilities.fromJson(params['hover'])
               : null,
           params.containsKey('onTypeFormatting') &&
                   params['onTypeFormatting'] != null
@@ -1989,7 +2137,7 @@ class TextDocumentClientCapabilities {
 
   final DynamicRegistrationCapability formatting;
 
-  final DynamicRegistrationCapability hover;
+  final HoverCapabilities hover;
 
   final DynamicRegistrationCapability onTypeFormatting;
 
@@ -2073,7 +2221,7 @@ class TextDocumentClientCapabilities$Builder {
 
   DynamicRegistrationCapability formatting;
 
-  DynamicRegistrationCapability hover;
+  HoverCapabilities hover;
 
   DynamicRegistrationCapability onTypeFormatting;
 

--- a/lib/src/protocol/language_server/messages.yaml
+++ b/lib/src/protocol/language_server/messages.yaml
@@ -121,10 +121,15 @@ CompletionCapabilities:
   dynamicRegistration: bool
   completionItem: CompletionItemCapabilities
 
+HoverCapabilities:
+  dynamicRegistration: bool
+  contentFormat:
+    listType: String
+
 TextDocumentClientCapabilities:
   synchronization: SynchronizationCapabilities
   completion: CompletionCapabilities
-  hover: DynamicRegistrationCapability
+  hover: HoverCapabilities
   references: DynamicRegistrationCapability
   documentHighlight: DynamicRegistrationCapability
   documentSymbol: DynamicRegistrationCapability
@@ -208,6 +213,10 @@ Hover:
   contents: String
   range: Range
 
+HoverMarkup:
+  contents: MarkupContent
+  range: Range
+
 CodeActionContext:
   diagnostics:
     listType: Diagnostic
@@ -269,3 +278,7 @@ SymbolKind:
     operator: 25
     typeParameter: 26
   wireType: int
+
+MarkupContent:
+  kind: String # TODO: This should be 'plaintext' | 'markdown';
+  value: String

--- a/lib/src/protocol/language_server/messages.yaml
+++ b/lib/src/protocol/language_server/messages.yaml
@@ -279,6 +279,12 @@ SymbolKind:
     typeParameter: 26
   wireType: int
 
+MarkupContentKind:
+  enumValues:
+    plaintext: 'plaintext'
+    markdown: 'markdown'
+  wireType: String
+
 MarkupContent:
-  kind: String # TODO: This should be 'plaintext' | 'markdown';
+  kind: MarkupContentKind
   value: String

--- a/lib/src/shim.dart
+++ b/lib/src/shim.dart
@@ -293,7 +293,6 @@ class AnalysisServerAdapter extends LanguageServer {
   }
 
   @override
-  // TODO(dantup): How to make this Future<Hover | HoverMarkup>?!
   Future<dynamic> textDocumentHover(
       TextDocumentIdentifier documentId, Position position) {
     final path = _filePath(documentId.uri);


### PR DESCRIPTION
This is progress towards #40. It adds a new Hover type where `content` is a `MarkupContent` instead of `String`. Couple of things that need addressing:

1. Since Dart doesn't have union types, I've had to temporarily change the return type to `Future<dynamic>` to make this work. I'm not sure how best to fix this - since `content` is a different type for each, I can't come up with any solution that doesn't have issues :(

2. MarkupContent.kind can only be `plaintext` or `markdown` at our end (though probably we shouldn't assume that's they're the only things a client can send) but currently we can put any string in here. Again, not sure how to fix this (in TypeScript you can define a type as `"plaintext" | "markdown"` and it'll check you only supply those strings). As a minimum we could have constants, but not sure if message_builder supports that.

3. I'm currently just returning the Markdown as the Plaintext version. I'm not really sure how far we want to go with Markdown->Text translation.