### PR TITLE
Move logs into folder and allow overriding

### DIFF
--- a/lib/src/args.dart
+++ b/lib/src/args.dart
@@ -2,20 +2,24 @@ import 'package:args/args.dart';
 import 'package:meta/meta.dart';
 
 const _forceTraceLevel = 'force_trace_level';
+const _logFolder = 'log_folder';
 
 class StartupArgs {
   List<String> analysisServerArgs;
   String forceTraceLevel;
+  String logFolder;
 
   factory StartupArgs(List<String> args) {
     final parser = new ArgParser()
       ..addOption(_forceTraceLevel,
-          help: 'Override the `trace` option duriong initialization',
-          allowed: ['trace', 'verbose', 'off']);
+          help: 'Override the `trace` option during initialization',
+          allowed: ['trace', 'verbose', 'off'])
+      ..addOption(_logFolder, help: 'Override the log folder');
     try {
       final result = parser.parse(args);
       return new StartupArgs._(
         forceTraceLevel: result[_forceTraceLevel],
+        logFolder: result[_logFolder],
         analysisServerArgs: result.rest,
       );
     } catch (_) {
@@ -25,8 +29,10 @@ class StartupArgs {
 
   StartupArgs._({
     @required String forceTraceLevel,
+    @required String logFolder,
     @required List<String> analysisServerArgs,
   })  : forceTraceLevel = forceTraceLevel,
+        logFolder = logFolder,
         analysisServerArgs = analysisServerArgs;
 }
 

--- a/lib/src/args.dart
+++ b/lib/src/args.dart
@@ -2,24 +2,24 @@ import 'package:args/args.dart';
 import 'package:meta/meta.dart';
 
 const _forceTraceLevel = 'force_trace_level';
-const _logFolder = 'log_folder';
+const _logDirectory = 'log-directory';
 
 class StartupArgs {
   List<String> analysisServerArgs;
   String forceTraceLevel;
-  String logFolder;
+  String logDirectory;
 
   factory StartupArgs(List<String> args) {
     final parser = new ArgParser()
       ..addOption(_forceTraceLevel,
           help: 'Override the `trace` option during initialization',
           allowed: ['trace', 'verbose', 'off'])
-      ..addOption(_logFolder, help: 'Override the log folder');
+      ..addOption(_logDirectory, help: 'Override the log directory');
     try {
       final result = parser.parse(args);
       return new StartupArgs._(
         forceTraceLevel: result[_forceTraceLevel],
-        logFolder: result[_logFolder],
+        logDirectory: result[_logDirectory],
         analysisServerArgs: result.rest,
       );
     } catch (_) {
@@ -29,10 +29,10 @@ class StartupArgs {
 
   StartupArgs._({
     @required String forceTraceLevel,
-    @required String logFolder,
+    @required String logDirectory,
     @required List<String> analysisServerArgs,
   })  : forceTraceLevel = forceTraceLevel,
-        logFolder = logFolder,
+        logDirectory = logDirectory,
         analysisServerArgs = analysisServerArgs;
 }
 

--- a/lib/src/logging/logs.dart
+++ b/lib/src/logging/logs.dart
@@ -14,11 +14,10 @@ StreamChannelTransformer<String, String> lspChannel = _lspWireLog.transformer;
 
 final _logs = <IOSink>[];
 
-void startLogging(String clientName, String traceLevel) {
+void startLogging(Directory logFolder, String traceLevel) {
   if (traceLevel == 'verbose') {
-    var logSink = new File(path.join(
-            Directory.systemTemp.path, 'dart-lang-server-$clientName.log'))
-        .openWrite();
+    logFolder.createSync(recursive: true);
+    var logSink = new File(path.join(logFolder.path, 'server.log')).openWrite();
     _logs.add(logSink);
     Logger.root.level = Level.ALL;
     Logger.root.onRecord.listen((record) {
@@ -31,14 +30,13 @@ void startLogging(String clientName, String traceLevel) {
     });
   }
   if (traceLevel == 'verbose' || traceLevel == 'messages') {
-    var analyzerLog = new File(path.join(
-            Directory.systemTemp.path, 'analyzer-wirelog-$clientName.log'))
-        .openWrite();
+    logFolder.createSync(recursive: true);
+    var analyzerLog =
+        new File(path.join(logFolder.path, 'analyzer-wirelog.log')).openWrite();
     analyzerSink.stream.transform(utf8.encoder).pipe(analyzerLog);
     _logs.add(analyzerLog);
-    var lspLog = new File(
-            path.join(Directory.systemTemp.path, 'lsp-wirelog-$clientName.log'))
-        .openWrite();
+    var lspLog =
+        new File(path.join(logFolder.path, 'lsp-wirelog.log')).openWrite();
     _lspWireLog.attach(lspLog);
     _logs.add(lspLog);
   }

--- a/lib/src/logging/logs.dart
+++ b/lib/src/logging/logs.dart
@@ -14,10 +14,10 @@ StreamChannelTransformer<String, String> lspChannel = _lspWireLog.transformer;
 
 final _logs = <IOSink>[];
 
-void startLogging(Directory logFolder, String traceLevel) {
+void startLogging(Directory logDirectory, String traceLevel) {
   if (traceLevel == 'verbose') {
-    logFolder.createSync(recursive: true);
-    var logSink = new File(path.join(logFolder.path, 'server.log')).openWrite();
+    logDirectory.createSync(recursive: true);
+    var logSink = new File(path.join(logDirectory.path, 'server.log')).openWrite();
     _logs.add(logSink);
     Logger.root.level = Level.ALL;
     Logger.root.onRecord.listen((record) {
@@ -30,13 +30,13 @@ void startLogging(Directory logFolder, String traceLevel) {
     });
   }
   if (traceLevel == 'verbose' || traceLevel == 'messages') {
-    logFolder.createSync(recursive: true);
+    logDirectory.createSync(recursive: true);
     var analyzerLog =
-        new File(path.join(logFolder.path, 'analyzer-wirelog.log')).openWrite();
+        new File(path.join(logDirectory.path, 'analyzer-wirelog.log')).openWrite();
     analyzerSink.stream.transform(utf8.encoder).pipe(analyzerLog);
     _logs.add(analyzerLog);
     var lspLog =
-        new File(path.join(logFolder.path, 'lsp-wirelog.log')).openWrite();
+        new File(path.join(logDirectory.path, 'lsp-wirelog.log')).openWrite();
     _lspWireLog.attach(lspLog);
     _logs.add(lspLog);
   }

--- a/lib/src/shim.dart
+++ b/lib/src/shim.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:analysis_server_lib/analysis_server_lib.dart'
     hide Position, Location;
@@ -61,9 +62,14 @@ class AnalysisServerAdapter extends LanguageServer {
   Future<ServerCapabilities> initialize(int clientPid, String rootUri,
       ClientCapabilities clientCapabilities, String trace) async {
     this.clientCapabilities = clientCapabilities;
-    final directory = _filePath(rootUri);
-    final clientName = '${p.basename(directory)}-$clientPid';
-    startLogging(clientName, _args.forceTraceLevel ?? trace);
+    String logFolder = _args.logFolder;
+    if (logFolder == null) {
+      final directory = _filePath(rootUri);
+      final clientName = '${p.basename(directory)}-$clientPid';
+      logFolder =
+          p.join(Directory.systemTemp.path, 'dart-lang-server-$clientName');
+    }
+    startLogging(new Directory(logFolder), _args.forceTraceLevel ?? trace);
     return serverCapabilities;
   }
 

--- a/lib/src/shim.dart
+++ b/lib/src/shim.dart
@@ -62,14 +62,14 @@ class AnalysisServerAdapter extends LanguageServer {
   Future<ServerCapabilities> initialize(int clientPid, String rootUri,
       ClientCapabilities clientCapabilities, String trace) async {
     this.clientCapabilities = clientCapabilities;
-    String logFolder = _args.logFolder;
-    if (logFolder == null) {
+    String logDirectory = _args.logDirectory;
+    if (logDirectory == null) {
       final directory = _filePath(rootUri);
       final clientName = '${p.basename(directory)}-$clientPid';
-      logFolder =
+      logDirectory =
           p.join(Directory.systemTemp.path, 'dart-lang-server-$clientName');
     }
-    startLogging(new Directory(logFolder), _args.forceTraceLevel ?? trace);
+    startLogging(new Directory(logDirectory), _args.forceTraceLevel ?? trace);
     return serverCapabilities;
   }
 


### PR DESCRIPTION
By default the logging has the directory name + pid in the filename which means if you're restart the project a lot (eg. closing/re-opening projects while working on integration) it's a pain to find the logs (especially for me on Windows where everything is spewing into the temp folder).

This moves the logs into a folder instead of lose in the temp folder, but also allows the folder to be overridden with a flag. This makes it much easier for me to work on/debug the VS integration.