### PR TITLE
Use analyzerLog directly as a StringSink

### DIFF
--- a/lib/src/logging/logs.dart
+++ b/lib/src/logging/logs.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:logging/logging.dart';
@@ -9,7 +8,7 @@ import 'package:stream_channel/stream_channel.dart';
 import 'wirelog.dart';
 
 final _lspWireLog = new WireLog();
-final analyzerSink = new StreamController<String>.broadcast();
+StringSink analyzerLog;
 StreamChannelTransformer<String, String> lspChannel = _lspWireLog.transformer;
 
 final _logs = <IOSink>[];
@@ -31,10 +30,9 @@ void startLogging(String clientName, String traceLevel) {
     });
   }
   if (traceLevel == 'verbose' || traceLevel == 'messages') {
-    var analyzerLog = new File(path.join(
+    analyzerLog = new File(path.join(
             Directory.systemTemp.path, 'analyzer-wirelog-$clientName.log'))
         .openWrite();
-    analyzerSink.stream.transform(utf8.encoder).pipe(analyzerLog);
     _logs.add(analyzerLog);
     var lspLog = new File(
             path.join(Directory.systemTemp.path, 'lsp-wirelog-$clientName.log'))

--- a/lib/src/shim.dart
+++ b/lib/src/shim.dart
@@ -23,8 +23,8 @@ import 'utils/per_file_pool.dart';
 
 Future<LanguageServer> startShimmedServer(StartupArgs args) async {
   var client = await AnalysisServer.create(
-      onRead: (m) => analyzerSink.add('OUT: $m\n'),
-      onWrite: (m) => analyzerSink.add('IN: $m\n'),
+      onRead: (m) => analyzerLog?.writeln('OUT: $m'),
+      onWrite: (m) => analyzerLog?.writeln('IN: $m'),
       serverArgs: args.analysisServerArgs);
   await client.server.onConnected.first;
   return new AnalysisServerAdapter(client, args);


### PR DESCRIPTION
Allows us to use writeln instead of manually encoding and adding
newlines.