### PR TITLE
Fix some new static warnings in dev SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.13+1
+
+- Fix some static warnings for dev SDK.
+
 # 0.1.13
 
 - Rename `--force_trace_level` argument to `--force-trace-level`. Keep the old

--- a/lib/src/protocol/language_server/server.dart
+++ b/lib/src/protocol/language_server/server.dart
@@ -64,15 +64,15 @@ class StdIOLanguageServer {
   }
 
   void _fileHandlingMethods(Peer peer) {
-    _registerNotification(peer, 'textDocument/didOpen', (params) async {
-      await _server.textDocumentDidOpen(_documentItem(params));
+    _registerNotification(peer, 'textDocument/didOpen', (params) {
+      _server.textDocumentDidOpen(_documentItem(params));
     });
-    _registerNotification(peer, 'textDocument/didChange', (params) async {
-      await _server.textDocumentDidChange(
+    _registerNotification(peer, 'textDocument/didChange', (params) {
+      _server.textDocumentDidChange(
           _versionedDocument(params), _contentChanges(params));
     });
-    _registerNotification(peer, 'textDocument/didClose', (params) async {
-      await _server.textDocumentDidClose(_document(params));
+    _registerNotification(peer, 'textDocument/didClose', (params) {
+      _server.textDocumentDidClose(_document(params));
     });
   }
 

--- a/lib/src/shim.dart
+++ b/lib/src/shim.dart
@@ -102,7 +102,7 @@ class AnalysisServerAdapter extends LanguageServer {
   Future<void> shutdown() async {
     _hasShutdown = true;
     await _subscriptions.close();
-    await _server.dispose();
+    _server.dispose();
   }
 
   @override

--- a/lib/src/utils/per_file_pool.dart
+++ b/lib/src/utils/per_file_pool.dart
@@ -16,5 +16,6 @@ class PerFilePool {
   Future<T> Function() _timeout<T>(Future<T> Function() operation) =>
       () => operation().timeout(const Duration(seconds: 2), onTimeout: () {
             _log.warning('Operation timed out!');
+            return null;
           });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_language_server
-version: 0.1.13
+version: 0.1.13+1
 description: >-
   A shim on the analysis server following the language server protocol
 homepage: https://github.com/natebosch/dart_language_server


### PR DESCRIPTION
These may not be warnings in the next stable SDK, but fix them anyway.