### PR TITLE
Set insertTextFormat explicitly to avoid null

### DIFF
--- a/lib/src/shim.dart
+++ b/lib/src/shim.dart
@@ -631,10 +631,6 @@ CompletionItem _toCompletionItem(List<int> lineLengths,
   return CompletionItem((b) => b
     ..label = symbol
     ..kind = _completionKind(suggestion)
-    // The LSP doesn't allow for nulls. Visual Studio hangs if it gets a null
-    // insertTextFormat so we explicitly set it to plainText here while we don't
-    // support snippets.
-    // https://github.com/natebosch/dart_language_server/issues/34
     ..insertTextFormat = InsertTextFormat.plainText
     ..textEdit = TextEdit((b) => b
       ..newText = symbol

--- a/lib/src/shim.dart
+++ b/lib/src/shim.dart
@@ -631,6 +631,11 @@ CompletionItem _toCompletionItem(List<int> lineLengths,
   return CompletionItem((b) => b
     ..label = symbol
     ..kind = _completionKind(suggestion)
+    // The LSP doesn't allow for nulls. Visual Studio hangs if it gets a null
+    // insertTextFormat so we explicitly set it to plainText here while we don't
+    // support snippets.
+    // https://github.com/natebosch/dart_language_server/issues/34
+    ..insertTextFormat = InsertTextFormat.plainText
     ..textEdit = TextEdit((b) => b
       ..newText = symbol
       ..range = rangeFromOffset(


### PR DESCRIPTION
Fixes one issue from #34 but there may well be more (we send a lot of nulls currently).