### PR TITLE
Set the `executeCommandProvider` capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.14
+
+- Set the `executeCommandProvider` capability.
+
 # 0.1.13+2
 
 - Correct `documentHighlightsProviers` capability `documentHighlightProvider`.

--- a/lib/src/capabilities.dart
+++ b/lib/src/capabilities.dart
@@ -10,6 +10,8 @@ final serverCapabilities = ServerCapabilities((b) => b
   ..completionProvider = CompletionOptions((b) => b
     ..resolveProvider = false
     ..triggerCharacters = const ['.'])
+  ..executeCommandProvider = ExecuteCommandOptions(
+      (b) => b..commands = const ['sort members', 'organize imports'])
   ..codeActionProvider = true
   ..definitionProvider = true
   ..documentHighlightProvider = true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_language_server
-version: 0.1.13+2
+version: 0.1.14-dev
 description: >-
   A shim on the analysis server following the language server protocol
 homepage: https://github.com/natebosch/dart_language_server


### PR DESCRIPTION
Fixes #56

Should allow clients to execute the "sort members" or "organize imports"
commands.